### PR TITLE
Api endpoint update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.phar
 /vendor/
 .idea
+.phpunit.result.cache

--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -8,6 +8,7 @@ use AlphaVantage\Exception\RuntimeException;
 use AlphaVantage\Options;
 use GuzzleHttp\Client;
 
+use function array_filter;
 use function GuzzleHttp\json_decode;
 use function http_build_query;
 use function array_merge;
@@ -47,6 +48,10 @@ class AbstractApi
     protected function get(string $functionName, string $symbolName = null, array $params = [])
     {
         unset($params['functions'], $params['function'], $params['apikey']);
+
+        $params = array_filter($params, function ($p) {
+            return !empty($p);
+        });
 
         $basicData = [
             'function' => $functionName,

--- a/src/Api/DigitalCurrency.php
+++ b/src/Api/DigitalCurrency.php
@@ -17,8 +17,10 @@ class DigitalCurrency extends AbstractApi
      * @param null|string $dataType
      * @return array
      */
-    public function digitalCurrencyRating(string $symbol, ?string $dataType = null)
-    {
+    public function digitalCurrencyRating(
+        string $symbol,
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
         return $this->get(
             'CRYPTO_RATING',
             $symbol,
@@ -35,8 +37,12 @@ class DigitalCurrency extends AbstractApi
      * @param null|string $dataType
      * @return array
      */
-    public function digitalCurrencyIntraday(string $symbol, string $market, string $interval, ?string $dataType = null)
-    {
+    public function digitalCurrencyIntraday(
+        string $symbol,
+        string $market,
+        string $interval,
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
         return $this->get(
             'CRYPTO_INTRADAY',
             $symbol,
@@ -54,8 +60,11 @@ class DigitalCurrency extends AbstractApi
      * @param null|string $dataType
      * @return array
      */
-    public function digitalCurrencyDaily(string $symbol, string $market, ?string $dataType = null)
-    {
+    public function digitalCurrencyDaily(
+        string $symbol,
+        string $market,
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
         return $this->get(
             'DIGITAL_CURRENCY_DAILY',
             $symbol,
@@ -72,8 +81,11 @@ class DigitalCurrency extends AbstractApi
      * @param null|string $dataType
      * @return array
      */
-    public function digitalCurrencyWeekly(string $symbol, string $market, ?string $dataType = null)
-    {
+    public function digitalCurrencyWeekly(
+        string $symbol,
+        string $market,
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
         return $this->get(
             'DIGITAL_CURRENCY_WEEKLY',
             $symbol,
@@ -90,8 +102,11 @@ class DigitalCurrency extends AbstractApi
      * @param null|string $dataType
      * @return array
      */
-    public function digitalCurrencyMonthly(string $symbol, string $market, ?string $dataType = null)
-    {
+    public function digitalCurrencyMonthly(
+        string $symbol,
+        string $market,
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
         return $this->get(
             'DIGITAL_CURRENCY_MONTHLY',
             $symbol,

--- a/src/Api/DigitalCurrency.php
+++ b/src/Api/DigitalCurrency.php
@@ -6,19 +6,23 @@ namespace AlphaVantage\Api;
 
 class DigitalCurrency extends AbstractApi
 {
+    public const INTERVAL_1 = '1min';
+    public const INTERVAL_5 = '5min';
+    public const INTERVAL_15 = '15min';
+    public const INTERVAL_30 = '30min';
+    public const INTERVAL_60 = '60min';
+
     /**
      * @param string $symbol
-     * @param string $market
-     * @param string $dataType
+     * @param null|string $dataType
      * @return array
      */
-    public function digitalCurrencyIntraday(string $symbol, string $market, string $dataType = self::DATA_TYPE_JSON)
+    public function digitalCurrencyRating(string $symbol, ?string $dataType = null)
     {
         return $this->get(
-            'DIGITAL_CURRENCY_INTRADAY',
+            'CRYPTO_RATING',
             $symbol,
             [
-                'market' => $market,
                 'datatype' => $dataType,
             ]
         );
@@ -27,10 +31,30 @@ class DigitalCurrency extends AbstractApi
     /**
      * @param string $symbol
      * @param string $market
-     * @param string $dataType
+     * @param string $interval
+     * @param null|string $dataType
      * @return array
      */
-    public function digitalCurrencyDaily(string $symbol, string $market, string $dataType = self::DATA_TYPE_JSON)
+    public function digitalCurrencyIntraday(string $symbol, string $market, string $interval, ?string $dataType = null)
+    {
+        return $this->get(
+            'CRYPTO_INTRADAY',
+            $symbol,
+            [
+                'market' => $market,
+                'interval' => $interval,
+                'datatype' => $dataType,
+            ]
+        );
+    }
+
+    /**
+     * @param string $symbol
+     * @param string $market
+     * @param null|string $dataType
+     * @return array
+     */
+    public function digitalCurrencyDaily(string $symbol, string $market, ?string $dataType = null)
     {
         return $this->get(
             'DIGITAL_CURRENCY_DAILY',
@@ -45,10 +69,10 @@ class DigitalCurrency extends AbstractApi
     /**
      * @param string $symbol
      * @param string $market
-     * @param string $dataType
+     * @param null|string $dataType
      * @return array
      */
-    public function digitalCurrencyWeekly(string $symbol, string $market, string $dataType = self::DATA_TYPE_JSON)
+    public function digitalCurrencyWeekly(string $symbol, string $market, ?string $dataType = null)
     {
         return $this->get(
             'DIGITAL_CURRENCY_WEEKLY',
@@ -63,10 +87,10 @@ class DigitalCurrency extends AbstractApi
     /**
      * @param string $symbol
      * @param string $market
-     * @param string $dataType
+     * @param null|string $dataType
      * @return array
      */
-    public function digitalCurrencyMonthly(string $symbol, string $market, string $dataType = self::DATA_TYPE_JSON)
+    public function digitalCurrencyMonthly(string $symbol, string $market, ?string $dataType = null)
     {
         return $this->get(
             'DIGITAL_CURRENCY_MONTHLY',

--- a/src/Api/Economics.php
+++ b/src/Api/Economics.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlphaVantage\Api;
+
+class Economics extends AbstractApi
+{
+    public const INTERVAL_DAILY = 'daily';
+    public const INTERVAL_WEEKLY = 'weekly';
+    public const INTERVAL_MONTHLY = 'monthly';
+    public const INTERVAL_QUARTERLY = 'quarterly';
+    public const INTERVAL_ANNUAL = 'annual';
+
+    public const MATURITY_3MONTH = '3month';
+    public const MATURITY_5YEAR = '5year';
+    public const MATURITY_10YEAR = '10year';
+    public const MATURITY_30YEAR = '30year';
+
+    /**
+     * @param string $interval
+     * @param null|string $dataType
+     * @return array
+     */
+    public function realGdp(
+        string $interval = self::INTERVAL_ANNUAL,
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'REAL_GDP',
+            null,
+            [
+                'interval' => $interval,
+                'datatype' => $dataType,
+            ]
+        );
+    }
+
+    /**
+     * @param null|string $dataType
+     * @return array
+     */
+    public function realGdpPerCapita(?string $dataType = self::DATA_TYPE_JSON)
+    {
+        return $this->get(
+            'REAL_GDP_PER_CAPITA',
+            null,
+            [
+                'datatype' => $dataType,
+            ]
+        );
+    }
+
+    /**
+     * @param string $interval
+     * @param string $maturity
+     * @param null|string $dataType
+     * @return array
+     */
+    public function treasuryYield(
+        string $interval = self::INTERVAL_MONTHLY,
+        string $maturity = self::MATURITY_10YEAR,
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'TREASURY_YIELD',
+            null,
+            [
+                'interval' => $interval,
+                'maturity' => $maturity,
+                'datatype' => $dataType,
+            ]
+        );
+    }
+
+    /**
+     * @param string $interval
+     * @param null|string $dataType
+     * @return array
+     */
+    public function federalFundsRate(
+        string $interval = self::INTERVAL_MONTHLY,
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'FEDERAL_FUNDS_RATE',
+            null,
+            [
+                'interval' => $interval,
+                'datatype' => $dataType,
+            ]
+        );
+    }
+
+    /**
+     * @param string $interval
+     * @param null|string $dataType
+     * @return array
+     */
+    public function cpi(
+        string $interval = self::INTERVAL_MONTHLY,
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'CPI',
+            null,
+            [
+                'interval' => $interval,
+                'datatype' => $dataType,
+            ]
+        );
+    }
+
+    /**
+     * @param null|string $dataType
+     * @return array
+     */
+    public function inflation(
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'INFLATION',
+            null,
+            [
+                'datatype' => $dataType,
+            ]
+        );
+    }
+
+    /**
+     * @param null|string $dataType
+     * @return array
+     */
+    public function inflationExpectation(
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'INFLATION_EXPECTATION',
+            null,
+            [
+                'datatype' => $dataType,
+            ]
+        );
+    }
+
+    /**
+     * @param null|string $dataType
+     * @return array
+     */
+    public function consumerSentiment(
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'CONSUMER_SENTIMENT',
+            null,
+            [
+                'datatype' => $dataType,
+            ]
+        );
+    }
+
+    /**
+     * @param null|string $dataType
+     * @return array
+     */
+    public function retailSales(
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'RETAIL_SALES',
+            null,
+            [
+                'datatype' => $dataType,
+            ]
+        );
+    }
+
+    /**
+     * @param null|string $dataType
+     * @return array
+     */
+    public function durables(
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'DURABLES',
+            null,
+            [
+                'datatype' => $dataType,
+            ]
+        );
+    }
+
+    /**
+     * @param null|string $dataType
+     * @return array
+     */
+    public function unemployment(
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'UNEMPLOYMENT',
+            null,
+            [
+                'datatype' => $dataType,
+            ]
+        );
+    }
+
+    /**
+     * @param null|string $dataType
+     * @return array
+     */
+    public function nonfarmPayroll(
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'NONFARM_PAYROLL',
+            null,
+            [
+                'datatype' => $dataType,
+            ]
+        );
+    }
+}

--- a/src/Api/Fundamentals.php
+++ b/src/Api/Fundamentals.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlphaVantage\Api;
+
+use DateTime;
+
+class Fundamentals extends AbstractApi
+{
+    public const STATE_ACTIVE = 'active';
+    public const STATE_DELISTED = 'delisted';
+
+    public const HORIZON_3MONTH = '3month';
+    public const HORIZON_6MONTH = '6month';
+    public const HORIZON_12MONTH = '12month';
+
+    /**
+     * @param string $symbol
+     * @param null|string $dataType
+     * @return array
+     */
+    public function companyOverview(
+        string  $symbol,
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'OVERVIEW',
+            $symbol,
+            [
+                'datatype' => $dataType,
+            ]
+        );
+    }
+
+    /**
+     * @param string $symbol
+     * @param null|string $dataType
+     * @return array
+     */
+    public function earnings(
+        string  $symbol,
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'EARNINGS',
+            $symbol,
+            [
+                'datatype' => $dataType,
+            ]
+        );
+    }
+
+    /**
+     * @param string $symbol
+     * @param null|string $dataType
+     * @return array
+     */
+    public function incomeStatement(
+        string  $symbol,
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'INCOME_STATEMENT',
+            $symbol,
+            [
+                'datatype' => $dataType,
+            ]
+        );
+    }
+
+    /**
+     * @param string $symbol
+     * @param null|string $dataType
+     * @return array
+     */
+    public function balanceSheet(
+        string  $symbol,
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'BALANCE_SHEET',
+            $symbol,
+            [
+                'datatype' => $dataType,
+            ]
+        );
+    }
+
+    /**
+     * @param string $symbol
+     * @param null|string $dataType
+     * @return array
+     */
+    public function cashFlow(
+        string  $symbol,
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'CASH_FLOW',
+            $symbol,
+            [
+                'datatype' => $dataType,
+            ]
+        );
+    }
+
+    /**
+     * @param string $status
+     * @param null|DateTime $date
+     * @param null|string $dataType
+     * @return array
+     */
+    public function listingStatus(
+        string    $status = self::STATE_ACTIVE,
+        ?DateTime $date = null,
+        ?string   $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'LISTING_STATUS',
+            null,
+            [
+                'status' => $status,
+                'datatype' => $dataType,
+                'date' => $date ? $date->format('Y-m-d') : null,
+            ]
+        );
+    }
+
+    /**
+     * @param string $horizon
+     * @param null|string $symbol
+     * @param null|string $dataType
+     * @return array
+     */
+    public function earningsCalendar(
+        string $horizon = self::HORIZON_3MONTH,
+        ?string $symbol = null,
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'EARNINGS_CALENDAR',
+            $symbol,
+            [
+                'horizon' => $horizon,
+                'datatype' => $dataType,
+            ]
+        );
+    }
+
+    /**
+     * @param null|string $dataType
+     * @return array
+     */
+    public function ipoCalendar(
+        ?string $dataType = self::DATA_TYPE_JSON
+    ) {
+        return $this->get(
+            'IPO_CALENDAR',
+            null,
+            [
+                'datatype' => $dataType,
+            ]
+        );
+    }
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -57,6 +57,9 @@ class Client
             case 'economics':
                 $api = new Api\Economics($this->options);
                 break;
+            case 'fundamentals':
+                $api = new Api\Fundamentals($this->options);
+                break;
 
             default:
                 throw new Exception\InvalidArgumentException(

--- a/src/Client.php
+++ b/src/Client.php
@@ -13,6 +13,7 @@ namespace AlphaVantage;
  * @method Api\Performance performance()
  * @method Api\ForeignExchange foreignExchange()
  * @method Api\DigitalCurrency digitalCurrency()
+ * @method Api\Economics economics()
  */
 class Client
 {
@@ -52,6 +53,9 @@ class Client
                 break;
             case 'digitalcurrency':
                 $api = new Api\DigitalCurrency($this->options);
+                break;
+            case 'economics':
+                $api = new Api\Economics($this->options);
                 break;
 
             default:

--- a/tests/Api/DigitalCurrencyTest.php
+++ b/tests/Api/DigitalCurrencyTest.php
@@ -10,7 +10,12 @@ class DigitalCurrencyTest extends TestCase
 {
     public function testDigitalCurrencyIntraday()
     {
-        $actual = (new DigitalCurrency($this->option))->digitalCurrencyIntraday('ETH', 'USD', DigitalCurrency::INTERVAL_5);
+        $actual = (new DigitalCurrency($this->option))->digitalCurrencyIntraday(
+            'ETH',
+            'USD',
+            DigitalCurrency::INTERVAL_5,
+            null
+        );
 
         $this->assertIsArray($actual);
         $this->assertCount(2, $actual);
@@ -24,7 +29,11 @@ class DigitalCurrencyTest extends TestCase
 
     public function testDigitalCurrencyDaily()
     {
-        $actual = (new DigitalCurrency($this->option))->digitalCurrencyDaily('BTC', 'CNY');
+        $actual = (new DigitalCurrency($this->option))->digitalCurrencyDaily(
+            'BTC',
+            'CNY',
+            null
+        );
 
         $this->assertIsArray($actual);
         $this->assertCount(2, $actual);
@@ -38,7 +47,11 @@ class DigitalCurrencyTest extends TestCase
 
     public function testDigitalCurrencyWeekly()
     {
-        $actual = (new DigitalCurrency($this->option))->digitalCurrencyWeekly('BTC', 'CNY');
+        $actual = (new DigitalCurrency($this->option))->digitalCurrencyWeekly(
+            'BTC',
+            'CNY',
+            null
+        );
 
         $this->assertIsArray($actual);
         $this->assertCount(2, $actual);
@@ -52,7 +65,11 @@ class DigitalCurrencyTest extends TestCase
 
     public function testDigitalCurrencyMonthly()
     {
-        $actual = (new DigitalCurrency($this->option))->digitalCurrencyMonthly('BTC', 'CNY');
+        $actual = (new DigitalCurrency($this->option))->digitalCurrencyMonthly(
+            'BTC',
+            'CNY',
+            null
+        );
 
         $this->assertIsArray($actual);
         $this->assertCount(2, $actual);

--- a/tests/Api/DigitalCurrencyTest.php
+++ b/tests/Api/DigitalCurrencyTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlphaVantageTest\Api;
+
+use AlphaVantage\Api\DigitalCurrency;
+
+class DigitalCurrencyTest extends TestCase
+{
+    public function testDigitalCurrencyIntraday()
+    {
+        $actual = (new DigitalCurrency($this->option))->digitalCurrencyIntraday('ETH', 'USD', DigitalCurrency::INTERVAL_5);
+
+        $this->assertIsArray($actual);
+        $this->assertCount(2, $actual);
+
+        $this->assertArrayHasKey('Meta Data', $actual);
+        $this->assertNotEmpty($actual['Meta Data']);
+
+        $this->assertArrayHasKey('Time Series Crypto (5min)', $actual);
+        $this->assertNotEmpty($actual['Time Series Crypto (5min)']);
+    }
+
+    public function testDigitalCurrencyDaily()
+    {
+        $actual = (new DigitalCurrency($this->option))->digitalCurrencyDaily('BTC', 'CNY');
+
+        $this->assertIsArray($actual);
+        $this->assertCount(2, $actual);
+
+        $this->assertArrayHasKey('Meta Data', $actual);
+        $this->assertNotEmpty($actual['Meta Data']);
+
+        $this->assertArrayHasKey('Time Series (Digital Currency Daily)', $actual);
+        $this->assertNotEmpty($actual['Time Series (Digital Currency Daily)']);
+    }
+
+    public function testDigitalCurrencyWeekly()
+    {
+        $actual = (new DigitalCurrency($this->option))->digitalCurrencyWeekly('BTC', 'CNY');
+
+        $this->assertIsArray($actual);
+        $this->assertCount(2, $actual);
+
+        $this->assertArrayHasKey('Meta Data', $actual);
+        $this->assertNotEmpty($actual['Meta Data']);
+
+        $this->assertArrayHasKey('Time Series (Digital Currency Weekly)', $actual);
+        $this->assertNotEmpty($actual['Time Series (Digital Currency Weekly)']);
+    }
+
+    public function testDigitalCurrencyMonthly()
+    {
+        $actual = (new DigitalCurrency($this->option))->digitalCurrencyMonthly('BTC', 'CNY');
+
+        $this->assertIsArray($actual);
+        $this->assertCount(2, $actual);
+
+        $this->assertArrayHasKey('Meta Data', $actual);
+        $this->assertNotEmpty($actual['Meta Data']);
+
+        $this->assertArrayHasKey('Time Series (Digital Currency Monthly)', $actual);
+        $this->assertNotEmpty($actual['Time Series (Digital Currency Monthly)']);
+    }
+}

--- a/tests/Api/EconomicsTest.php
+++ b/tests/Api/EconomicsTest.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlphaVantageTest\Api;
+
+use AlphaVantage\Api\Economics;
+
+class EconomicsTest extends TestCase
+{
+    public function testRealGdp()
+    {
+        $actual = (new Economics($this->option))->realGdp(
+            Economics::INTERVAL_ANNUAL,
+            null
+        );
+
+        $this->assertIsArray($actual);
+        $this->assertCount(4, $actual);
+
+        $this->assertArrayHasKey('name', $actual);
+        $this->assertSame('Real Gross Domestic Product', $actual['name']);
+
+        $this->assertArrayHasKey('interval', $actual);
+        $this->assertSame('annual', $actual['interval']);
+
+        $this->assertArrayHasKey('unit', $actual);
+        $this->assertSame('billions of dollars', $actual['unit']);
+
+        $this->assertArrayHasKey('data', $actual);
+        $this->assertNotEmpty($actual['data']);
+    }
+
+    public function testRealGdpPerCapita()
+    {
+        $actual = (new Economics($this->option))->realGdpPerCapita(null);
+
+        $this->assertIsArray($actual);
+        $this->assertCount(4, $actual);
+
+        $this->assertArrayHasKey('name', $actual);
+        $this->assertSame('Real Gross Domestic Product per Capita', $actual['name']);
+
+        $this->assertArrayHasKey('interval', $actual);
+        $this->assertSame('quarterly', $actual['interval']);
+
+        $this->assertArrayHasKey('unit', $actual);
+        $this->assertSame('chained 2012 dollars', $actual['unit']);
+
+        $this->assertArrayHasKey('data', $actual);
+        $this->assertNotEmpty($actual['data']);
+    }
+
+    public function testTreasuryYield()
+    {
+        $actual = (new Economics($this->option))->treasuryYield(
+            Economics::INTERVAL_MONTHLY,
+            Economics::MATURITY_10YEAR,
+            null
+        );
+
+        $this->assertIsArray($actual);
+        $this->assertCount(4, $actual);
+
+        $this->assertArrayHasKey('name', $actual);
+        $this->assertSame('10-Year Treasury Constant Maturity Rate', $actual['name']);
+
+        $this->assertArrayHasKey('interval', $actual);
+        $this->assertSame('monthly', $actual['interval']);
+
+        $this->assertArrayHasKey('unit', $actual);
+        $this->assertSame('percent', $actual['unit']);
+
+        $this->assertArrayHasKey('data', $actual);
+        $this->assertNotEmpty($actual['data']);
+    }
+
+    public function testFederalFundsRate()
+    {
+        $actual = (new Economics($this->option))->federalFundsRate(
+            Economics::INTERVAL_MONTHLY,
+            null
+        );
+
+        $this->assertIsArray($actual);
+        $this->assertCount(4, $actual);
+
+        $this->assertArrayHasKey('name', $actual);
+        $this->assertSame('Effective Federal Funds Rate', $actual['name']);
+
+        $this->assertArrayHasKey('interval', $actual);
+        $this->assertSame('monthly', $actual['interval']);
+
+        $this->assertArrayHasKey('unit', $actual);
+        $this->assertSame('percent', $actual['unit']);
+
+        $this->assertArrayHasKey('data', $actual);
+        $this->assertNotEmpty($actual['data']);
+    }
+
+    public function testCpi()
+    {
+        $actual = (new Economics($this->option))->cpi(
+            Economics::INTERVAL_MONTHLY,
+            null
+        );
+
+        $this->assertIsArray($actual);
+        $this->assertCount(4, $actual);
+
+        $this->assertArrayHasKey('name', $actual);
+        $this->assertSame('Consumer Price Index for all Urban Consumers', $actual['name']);
+
+        $this->assertArrayHasKey('interval', $actual);
+        $this->assertSame('monthly', $actual['interval']);
+
+        $this->assertArrayHasKey('unit', $actual);
+        $this->assertSame('index 1982-1984=100', $actual['unit']);
+
+        $this->assertArrayHasKey('data', $actual);
+        $this->assertNotEmpty($actual['data']);
+    }
+
+    public function testInflation()
+    {
+        $actual = (new Economics($this->option))->inflation(null);
+
+        $this->assertIsArray($actual);
+        $this->assertCount(4, $actual);
+
+        $this->assertArrayHasKey('name', $actual);
+        $this->assertSame('Inflation - US Consumer Prices', $actual['name']);
+
+        $this->assertArrayHasKey('interval', $actual);
+        $this->assertSame('annual', $actual['interval']);
+
+        $this->assertArrayHasKey('unit', $actual);
+        $this->assertSame('percent', $actual['unit']);
+
+        $this->assertArrayHasKey('data', $actual);
+        $this->assertNotEmpty($actual['data']);
+    }
+
+    public function testInflationExpectation()
+    {
+        $actual = (new Economics($this->option))->inflationExpectation(null);
+
+        $this->assertIsArray($actual);
+        $this->assertCount(4, $actual);
+
+        $this->assertArrayHasKey('name', $actual);
+        $this->assertSame('Inflation Expectations', $actual['name']);
+
+        $this->assertArrayHasKey('interval', $actual);
+        $this->assertSame('monthly', $actual['interval']);
+
+        $this->assertArrayHasKey('unit', $actual);
+        $this->assertSame('percent', $actual['unit']);
+
+        $this->assertArrayHasKey('data', $actual);
+        $this->assertNotEmpty($actual['data']);
+    }
+
+    public function testConsumerSentiment()
+    {
+        $actual = (new Economics($this->option))->consumerSentiment(null);
+
+        $this->assertIsArray($actual);
+        $this->assertCount(4, $actual);
+
+        $this->assertArrayHasKey('name', $actual);
+        $this->assertSame('Consumer Sentiment & Consumer Confidence', $actual['name']);
+
+        $this->assertArrayHasKey('interval', $actual);
+        $this->assertSame('monthly', $actual['interval']);
+
+        $this->assertArrayHasKey('unit', $actual);
+        $this->assertSame('index 1966:Q1=100', $actual['unit']);
+
+        $this->assertArrayHasKey('data', $actual);
+        $this->assertNotEmpty($actual['data']);
+    }
+
+    public function testRetailSales()
+    {
+        $actual = (new Economics($this->option))->retailSales(null);
+
+        $this->assertIsArray($actual);
+        $this->assertCount(4, $actual);
+
+        $this->assertArrayHasKey('name', $actual);
+        $this->assertSame('Advance Retail Sales: Retail Trade', $actual['name']);
+
+        $this->assertArrayHasKey('interval', $actual);
+        $this->assertSame('monthly', $actual['interval']);
+
+        $this->assertArrayHasKey('unit', $actual);
+        $this->assertSame('millions of dollars', $actual['unit']);
+
+        $this->assertArrayHasKey('data', $actual);
+        $this->assertNotEmpty($actual['data']);
+    }
+
+    public function testDurables()
+    {
+        $actual = (new Economics($this->option))->durables(null);
+
+        $this->assertIsArray($actual);
+        $this->assertCount(4, $actual);
+
+        $this->assertArrayHasKey('name', $actual);
+        $this->assertSame('Manufacturer New Orders: Durable Goods', $actual['name']);
+
+        $this->assertArrayHasKey('interval', $actual);
+        $this->assertSame('monthly', $actual['interval']);
+
+        $this->assertArrayHasKey('unit', $actual);
+        $this->assertSame('millions of dollars', $actual['unit']);
+
+        $this->assertArrayHasKey('data', $actual);
+        $this->assertNotEmpty($actual['data']);
+    }
+
+    public function testUnemployment()
+    {
+        $actual = (new Economics($this->option))->unemployment(null);
+
+        $this->assertIsArray($actual);
+        $this->assertCount(4, $actual);
+
+        $this->assertArrayHasKey('name', $actual);
+        $this->assertSame('Unemployment Rate', $actual['name']);
+
+        $this->assertArrayHasKey('interval', $actual);
+        $this->assertSame('monthly', $actual['interval']);
+
+        $this->assertArrayHasKey('unit', $actual);
+        $this->assertSame('percent', $actual['unit']);
+
+        $this->assertArrayHasKey('data', $actual);
+        $this->assertNotEmpty($actual['data']);
+    }
+
+    public function testNonfarmPayroll()
+    {
+        $actual = (new Economics($this->option))->nonfarmPayroll(null);
+
+        $this->assertIsArray($actual);
+        $this->assertCount(4, $actual);
+
+        $this->assertArrayHasKey('name', $actual);
+        $this->assertSame('Total Nonfarm Payroll', $actual['name']);
+
+        $this->assertArrayHasKey('interval', $actual);
+        $this->assertSame('monthly', $actual['interval']);
+
+        $this->assertArrayHasKey('unit', $actual);
+        $this->assertSame('thousands of persons', $actual['unit']);
+
+        $this->assertArrayHasKey('data', $actual);
+        $this->assertNotEmpty($actual['data']);
+    }
+}

--- a/tests/Api/FundamentalsTest.php
+++ b/tests/Api/FundamentalsTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlphaVantageTest\Api;
+
+use AlphaVantage\Api\Fundamentals;
+use DateTime;
+
+class FundamentalsTest extends TestCase
+{
+    public function testCompanyOverview()
+    {
+        $actual = (new Fundamentals($this->option))->companyOverview(
+            'IBM',
+            null
+        );
+
+        $this->assertIsArray($actual);
+        $this->assertCount(59, $actual);
+
+        $this->assertArrayHasKey('Symbol', $actual);
+        $this->assertSame('IBM', $actual['Symbol']);
+
+        $this->assertArrayHasKey('AssetType', $actual);
+        $this->assertSame('Common Stock', $actual['AssetType']);
+    }
+
+    public function testEarnings()
+    {
+        $actual = (new Fundamentals($this->option))->earnings(
+            'IBM',
+            null
+        );
+
+        $this->assertIsArray($actual);
+        $this->assertCount(3, $actual);
+
+        $this->assertArrayHasKey('symbol', $actual);
+        $this->assertSame('IBM', $actual['symbol']);
+
+        $this->assertArrayHasKey('annualEarnings', $actual);
+        $this->assertNotEmpty($actual['annualEarnings']);
+
+        $this->assertArrayHasKey('quarterlyEarnings', $actual);
+        $this->assertNotEmpty($actual['quarterlyEarnings']);
+    }
+
+    public function testIncomeStatement()
+    {
+        $actual = (new Fundamentals($this->option))->incomeStatement(
+            'IBM',
+            null
+        );
+
+        $this->assertIsArray($actual);
+        $this->assertCount(3, $actual);
+
+        $this->assertArrayHasKey('symbol', $actual);
+        $this->assertSame('IBM', $actual['symbol']);
+
+        $this->assertArrayHasKey('annualReports', $actual);
+        $this->assertNotEmpty($actual['annualReports']);
+
+        $this->assertArrayHasKey('quarterlyReports', $actual);
+        $this->assertNotEmpty($actual['quarterlyReports']);
+    }
+
+    public function testIncomeBalanceSheet()
+    {
+        $actual = (new Fundamentals($this->option))->balanceSheet(
+            'IBM',
+            null
+        );
+
+        $this->assertIsArray($actual);
+        $this->assertCount(3, $actual);
+
+        $this->assertArrayHasKey('symbol', $actual);
+        $this->assertSame('IBM', $actual['symbol']);
+
+        $this->assertArrayHasKey('annualReports', $actual);
+        $this->assertNotEmpty($actual['annualReports']);
+
+        $this->assertArrayHasKey('quarterlyReports', $actual);
+        $this->assertNotEmpty($actual['quarterlyReports']);
+    }
+
+    public function testIncomeCashFlow()
+    {
+        $actual = (new Fundamentals($this->option))->cashFlow(
+            'IBM',
+            null
+        );
+
+        $this->assertIsArray($actual);
+        $this->assertCount(3, $actual);
+
+        $this->assertArrayHasKey('symbol', $actual);
+        $this->assertSame('IBM', $actual['symbol']);
+
+        $this->assertArrayHasKey('annualReports', $actual);
+        $this->assertNotEmpty($actual['annualReports']);
+
+        $this->assertArrayHasKey('quarterlyReports', $actual);
+        $this->assertNotEmpty($actual['quarterlyReports']);
+    }
+
+    public function testListingStatus()
+    {
+        $actual = (new Fundamentals($this->option))->listingStatus(
+            Fundamentals::STATE_DELISTED,
+            new DateTime('2014-07-10'),
+            null
+        );
+
+        $this->assertIsArray($actual);
+    }
+}


### PR DESCRIPTION
Hey there,

I was looking for a php sdk for alpha vantage and found this package. Even if there are some general issues to address (like requesting a csv-response will fail on `json_decode`) I wanted start contributing with an update of supported endpoints and some test coverage.

Since the demo request URLs are really strict and dont allow for an additional `datatype=json` (even if it's the default value) I made those nullable and filter not set variables from the parameters before building the query.